### PR TITLE
Fix remove use of node import protocol

### DIFF
--- a/src/source$.ts
+++ b/src/source$.ts
@@ -1,4 +1,4 @@
-import assert from 'node:assert';
+import assert from 'assert';
 
 import { Observer, Source, SubscribeCallbacks, Subscription } from './defs/index.js';
 import { parseSubscribeArgs } from './utils/subscribe.js';


### PR DESCRIPTION
Use of this "node:" protocol is unsupported by Next