### PR TITLE
Potential fix for code scanning alert no. 2956: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,9 +113,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm
     needs: [ lint, build, tests ]
+    
     permissions:
       contents: read
-      packages: write
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm
     needs: [ lint, build, tests ]
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Potential fix for [https://github.com/Jujulego/kyrielle/security/code-scanning/2956](https://github.com/Jujulego/kyrielle/security/code-scanning/2956)

To fix the issue, we will add a `permissions` block to the `publish` job. This block will specify the minimal permissions required for the job to function correctly. Based on the job's steps, it interacts with repository contents (e.g., downloading artifacts and publishing to npm). Therefore, we will set `contents: read` and `packages: write` as the permissions. This ensures the job has only the necessary permissions and no more.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
