### PR TITLE
Potential fix for code scanning alert no. 2955: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,9 @@ jobs:
     name: 'Tests on node ${{ matrix.node }}'
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+
     strategy:
       matrix:
         node: ['18.x', '20.x', '22.x']


### PR DESCRIPTION
Potential fix for [https://github.com/Jujulego/kyrielle/security/code-scanning/2955](https://github.com/Jujulego/kyrielle/security/code-scanning/2955)

To fix the issue, add a `permissions` block to the `tests` job in the workflow file. Based on the steps in the `tests` job, it only needs `contents: read` permissions to access the repository contents for testing purposes. No write permissions are required.

The fix involves:
1. Adding a `permissions` block under the `tests` job.
2. Setting `contents: read` as the minimal required permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
