### PR TITLE
Potential fix for code scanning alert no. 2954: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
   build:
     name: 'Build'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
   build:
     name: 'Build'
     runs-on: ubuntu-latest
+    
     permissions:
       contents: read
 


### PR DESCRIPTION
Potential fix for [https://github.com/Jujulego/kyrielle/security/code-scanning/2954](https://github.com/Jujulego/kyrielle/security/code-scanning/2954)

To fix the issue, we will add a `permissions` block to the `build` job. Since the `build` job primarily involves checking out the repository, setting up Node.js, installing dependencies, building the project, and uploading artifacts, it only requires `contents: read` permission. This change will explicitly limit the permissions of the `GITHUB_TOKEN` to the minimum necessary for the job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
